### PR TITLE
CMAKE: Linux readme with added info on CMake

### DIFF
--- a/CMAKE.md
+++ b/CMAKE.md
@@ -29,7 +29,7 @@ CMake can create Xcode projects, which allow multi-configs (like Debug, Release,
 Configuring:
 
  - Install XCode and ensure command line tools are installed.
- - Install CMake 3.14 (via homebrew or from the above site)
+ - Install CMake (via homebrew or from the above site)
  - mkdir build
  - cd build
  - cmake -GXcode ..
@@ -48,10 +48,10 @@ There are multiple options from command line or IDE:
 CMake can create Makefile and Ninja projects. These are single config systems so they need to be manually specified.
 
  - Install recommended dev packages
- - Install CMake 3.14 (via above site)
- - mkdir build-debug
- - cd build-debug  # otherwise your build artifacts will be in the source directory!
- - cmake .. -DCMAKE_BUILD_TYPE=Debug
+ - Install CMake (via above site)
+ - mkdir build-release
+ - cd build-release  # otherwise your build artifacts will be in the source directory!
+ - cmake .. -DCMAKE_BUILD_TYPE=Release
  - cmake --build .
 
 

--- a/debian/README.md
+++ b/debian/README.md
@@ -1,46 +1,55 @@
 # Building the engine on any Linux
+
+There are two general ways to proceed: either use [**CMake**](../CMAKE.md) or install and build 
+everything yourself using Makefiles provided in the Engine's directory.
+
 Engine code demands at least partial C++11 support (uses std::shared_ptr, std::unique_ptr, etc).
 Known minimal versions of compilers that should work with AGS:
 
 -   GCC 4.4
+
+## Dependencies
 
 The following packages are required to build AGS. The versions in
 parentheses are known to work, but other versions will also
 probably work.
 
 -   libsdl2 (2.0.12 or higher)
--   libsdl_sound for sdl2 (revision ebcf0fe72544 or higher)
+-   libsdl_sound for sdl2 (revision 495e948b455a or higher)
 -   libogg (1.2.2-1.3.0)
 -   libtheora (1.1.1-1.2.0)
 -   libvorbis (1.3.2)
 
-There are two general ways to proceed: either use [CMake scripts](../CMAKE.md) or install and build everything yourself using Makefiles provided in the Engine's directory.
+If you are building using CMake, you have the option to let the CMake build system fetch and build the dependencies,
+or use locally installed libraries. This can be configured, and is [explained in CMake own readme](../CMAKE.md#using-locally-installed-libraries).
 
-Fedora package installation
----------------------------
+### Fedora package installation
+
     yum -y install git sdl2-devel libogg-devel libtheora-devel libvorbis-devel
 
-Debian/Ubuntu package installation
-----------------------------------
+### Debian/Ubuntu package installation
+
     sudo apt-get install git debhelper build-essential pkg-config libsdl2-dev libogg-dev libtheora-dev libvorbis-dev
 
 Other Linux systems use their respective package managers.
 
-SDL_Sound library installation
-----------------------------------
-At the time of writing SDL_Sound 2.* has just been released, but almost no linux distro provides it.
+## SDL_Sound library installation
+
+At the time of writing SDL_Sound `2.*` has just been released, but almost no linux distro provides it.
 Until that is resolved, we recommend to download particular revision archive using following url:
 
     https://github.com/icculus/SDL_sound/archive/495e948b455af48eb45f75cccc060498f1e0e8a2.tar.gz
 
 then build and install using CMake (see instructions in the SDL_Sound's docs).
 
-Download and build
-------------------
+## Download
+
 Download the source with git and change into the **ags** directory:
 
     git clone git://github.com/adventuregamestudio/ags.git
     cd ags
+    
+## Building AGS
 
 Compile the engine:
 
@@ -50,8 +59,22 @@ The **ags** executable can now be found in the **Engine** folder and
 can be installed with
 
     sudo make --directory=Engine install
+    
+In case you are using CMake there are different ways you can do, and it's better to read in 
+[**CMake README**](../CMAKE.md), following is an example of the default cmake release build.
+
+    mkdir build-release
+    cd build-release
+    cmake -S .. -B . -DCMAKE_BUILD_TYPE=Release
+    cmake --build .
+    
+The CMake way to install would be
+
+    cmake --install .
+
 
 # Building a Debian/Ubuntu package of AGS
+
 Building a package is the preferred way to install software on
 Debian/Ubuntu. This is how it's done.
 
@@ -65,7 +88,9 @@ Build the package and install it with gdebi:
     fakeroot debian/rules binary
     sudo gdebi ../ags_3~git-1_*.deb
 
+
 # Using the engine
+
 To start an AGS game, just run ags with the game directory or the game
 file as parameter, e.g.
 
@@ -107,9 +132,11 @@ If a plugin loads another custom library, present in the game dir, then normally
 
     LD_LIBRARY_PATH=path_to_game_dir/ ags path_to_game_dir
 
+
 # Debugging
-When using the Debian/Ubuntu package, the package ags-dbg_*.deb containing debugging
-symbols is created alongside ags_*.deb. The build date and the name of the
+
+When using the Debian/Ubuntu package, the package `ags-dbg_*.deb` containing debugging
+symbols is created alongside `ags_*.deb`. The build date and the name of the
 last git commit at the time of building are stored in the package description,
 which can be viewed with
 
@@ -117,12 +144,15 @@ which can be viewed with
 
 This information should be included in bug reports.
 
+
 # Building AGS for a game release
+
 If you want to build AGS for inclusion in a game release, you want an
 engine that runs on most 32 and 64 bit Linux systems regardless of the library
 versions that are installed on that system. You can get such a built by using
 the script **debian/make_ags+libraries.sh**. The script itself can be used
 on Debian or Ubuntu. See the comments in the script for instructions.
+
 
 # Workaround: 32 bit AGS on 64 bit Debian/Ubuntu
 In the past AGS worked only on 32 bit architectures, so it was necessary to compile
@@ -138,6 +168,7 @@ Download the sources with git and change into the **ags** directory:
 
     git clone git://github.com/adventuregamestudio/ags.git
     cd ags
+
 
 ## Matching working directory and orig tarball
 To build the package, it is required that there is an "orig tarball"


### PR DESCRIPTION
additionally, readjust CMake readme, remove version as it's best to use the latest when possible to reduce issues, and default for Release builds in readme, in case people are building as users.